### PR TITLE
nautible/issue#64 - quarkus vup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # nautible-app-ms-product project
 このドキュメントには商品アプリケーションについて記載する。  
-アプリケーション共通の内容については[こちら](https://github.com/nautible/docs/app-common/README.md)を参照。  
-Quarkusアプリケーション共通の内容については[こちら](https://github.com/nautible/docs/quarkus/README.md)を参照。
+アプリケーション共通の内容については[こちら](https://github.com/nautible/docs/blob/main/referenceapp-architecture/README.md)を参照。
+Quarkusアプリケーション共通の内容については[こちら](https://github.com/nautible/docs/blob/main/reference/quarkus/README.md)を参照。
 
 ## アプリケーションの主要アーキテクチャ
 * [Java11](https://www.oracle.com/java/)
@@ -26,7 +26,7 @@ Quarkusアプリケーション共通の内容については[こちら](https:/
 ### 事前準備
 * [dockerのインストール](https://docs.docker.com/get-docker/)
 * [minikubeのインストール](https://kubernetes.io/ja/docs/tasks/tools/install-minikube/)
-* [kubectlのインストール](https://kubernetes.io/ja/docs/tasks/tools/install-kubectl/)（接続先の設定をminikubeにする
+* [kubectlのインストール](https://kubernetes.io/ja/docs/tasks/tools/install-kubectl/)（接続先の設定をminikubeにする）
 * [skaffoldのインストール](https://skaffold.dev/docs/install/)
 * マニフェストファイルの配置
   [nautible-app-ms-product-manifest](https://github.com/nautible/nautible-app-ms-product-manifest)をnautible-app-ms-productプロジェクトと同一階層に配置する(git clone)。

--- a/pom.xml
+++ b/pom.xml
@@ -17,10 +17,10 @@
     <nautible.app.product.groupId>jp.co.ogis-ri.nautible.app</nautible.app.product.groupId>
     <nautible.app.product.name>nautible-app-ms-product</nautible.app.product.name>
     <nautible.app.product.version>1.0.0-SNAPSHOT</nautible.app.product.version>
-    <quarkus-plugin.version>1.13.6.Final</quarkus-plugin.version>
+    <quarkus-plugin.version>2.13.0.Final</quarkus-plugin.version>
     <quarkus.platform.artifact-id>quarkus-universe-bom</quarkus.platform.artifact-id>
     <quarkus.platform.group-id>io.quarkus</quarkus.platform.group-id>
-    <quarkus.platform.version>1.13.6.Final</quarkus.platform.version>
+    <quarkus.platform.version>2.13.0.Final</quarkus.platform.version>
     <commons-lang3.version>3.11</commons-lang3.version>
     <swagger-annotations.version>1.6.2</swagger-annotations.version>
     <surefire-plugin.version>3.0.0-M5</surefire-plugin.version>


### PR DESCRIPTION
# issue 64
## issue
- https://github.com/nautible/issues/issues/64

## 対応
- Quarkus の v2.13.0.Finalへのバージョンアップ
- READMEのTYPOとリンク切れ対応

## 詳細
- product サービスについては、単純バージョンアップで対応可能であった